### PR TITLE
Fix vector::operator()

### DIFF
--- a/src/Interfaces/BonTypes.hpp
+++ b/src/Interfaces/BonTypes.hpp
@@ -29,18 +29,11 @@ public:
 
 /** Access pointer to first element of storage.*/
 inline T* operator()(){
-#if defined(_MSC_VER)
-  if (std::vector<T>::size() == 0)
-    return NULL;
-#endif
-return &std::vector<T>::front();}
+  return &(*std::vector<T>::begin());
+}
 /** Access pointer to first element of storage.*/
 inline const T* operator()() const {
-#if defined(_MSC_VER)
-  if (std::vector<T>::size() == 0)
-    return NULL;
-#endif
-return &std::vector<T>::front();
+  return &(*std::vector<T>::begin());
 }
 };
 


### PR DESCRIPTION
The address of the iterator can be invalid when glibc assertions are
enabled (CXXFLAGS="-D_GLIBCXX_ASSERTIONS")
The address of begin first element pointed by begin() works, or better
vector::data() is even better if c++11 is allowed.

Here is the trace:

```
/usr/include/c++/10.2.0/bits/stl_vector.h:1123: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::front() [with _Tp = double; _Alloc = std::allocator<double>; std::vector<_Tp, _Alloc>::reference = double&]: Assertion '__builtin_expect(!this->empty(), true)' failed.

Program received signal SIGABRT, Aborted.
0x00007ffff7a63ef5 in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff7a63ef5 in raise () from /usr/lib/libc.so.6
#1  0x00007ffff7a4d862 in abort () from /usr/lib/libc.so.6
#2  0x00007ffff723c4b8 in std::__replacement_assert (__file=<optimized out>, __line=<optimized out>, __function=<optimized out>, __condition=<optimized out>) at /usr/include/c++/10.2.0/x86_64-pc-linux-gnu/bits/c++config.h:457
#3  0x00007ffff3aaecd0 in std::vector<double, std::allocator<double> >::front (this=0x7fffffffd3d0) at /usr/include/c++/10.2.0/bits/stl_vector.h:1121
#4  std::vector<double, std::allocator<double> >::front (this=0x7fffffffd3d0) at /usr/include/c++/10.2.0/bits/stl_vector.h:1121
#5  Bonmin::vector<double>::operator() (this=0x7fffffffd3d0) at BonTypes.hpp:36
#6  Bonmin::TMINLP::hasGeneralInteger (this=0x555555b7ff50) at BonTMINLP.cpp:123
#7  0x00007ffff3a532e7 in Bonmin::BonminSetup::initializeBBB (this=0x7fffffffddb0) at /usr/include/coin/IpSmartPtr.hpp:651
```
